### PR TITLE
build: install setuptools to address distutils deprecation

### DIFF
--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -13,7 +13,7 @@ unzip -o LexFloatClient-Static-Mac.zip -d ./tmp/macos
 
 cp ./tmp/macos/libs/clang/universal/libLexFloatClient.a ./
 npm i
-
+python3 -m pip install setuptools
 node-gyp rebuild 
 cp ./build/Release/lexfloatclient.node ./lib/bindings/macos/x64
 


### PR DESCRIPTION
Due to the deprecation of Distutils in Python version 3.10 and its subsequent removal in Python 3.12, adjustments were necessary in the build script.