### PR TITLE
Add LF_FAIL switch case

### DIFF
--- a/src/lexfloatclient.ts
+++ b/src/lexfloatclient.ts
@@ -299,6 +299,8 @@ export class LexFloatClient {
 				return true;
 			case LexFloatStatusCodes.LF_E_NO_LICENSE:
 				return false;
+			case LexFloatStatusCodes.LF_FAIL:
+				return false;
 			default:
 				throw new LexFloatClientException(status);
 		}


### PR DESCRIPTION
This pull request adds the LF_FAIL switch case to the LexFloatClient class. This case returns false, indicating that there was a failure in the licensing process. 