### PR TITLE
fix: add missing musl x64 package

### DIFF
--- a/scripts/build-linux-musl.sh
+++ b/scripts/build-linux-musl.sh
@@ -3,7 +3,6 @@
 echo "http://dl-cdn.alpinelinux.org/alpine/v3.12/main" > /etc/apk/repositories
 echo "http://dl-cdn.alpinelinux.org/alpine/v3.12/community" >> /etc/apk/repositories
 
-# Install Node.js 12 and required dependencies
 # Install Node.js 12 and essential tools
 apk update
 apk add --no-cache \

--- a/scripts/build-linux-musl.sh
+++ b/scripts/build-linux-musl.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# exit when any command fails
+set -e
 # Clear existing repositories and add correct ones
 echo "http://dl-cdn.alpinelinux.org/alpine/v3.12/main" > /etc/apk/repositories
 echo "http://dl-cdn.alpinelinux.org/alpine/v3.12/community" >> /etc/apk/repositories

--- a/scripts/build-linux-musl.sh
+++ b/scripts/build-linux-musl.sh
@@ -1,4 +1,25 @@
 #!/bin/sh
+# Clear existing repositories and add correct ones
+echo "http://dl-cdn.alpinelinux.org/alpine/v3.12/main" > /etc/apk/repositories
+echo "http://dl-cdn.alpinelinux.org/alpine/v3.12/community" >> /etc/apk/repositories
+
+# Install Node.js 12 and required dependencies
+# Install Node.js 12 and essential tools
+apk update
+apk add --no-cache \
+    nodejs=12.22.12-r0 \
+    libstdc++=9.3.0-r2 \
+    nghttp2-libs=1.41.0-r0 \
+    curl \
+    tar
+
+# Download and extract npm@6.14.15 without changing directory
+curl -L https://registry.npmjs.org/npm/-/npm-6.14.15.tgz -o npm.tgz
+mkdir -p .npm-upgrade
+tar -xzf npm.tgz -C .npm-upgrade --strip-components=1
+
+# Run npm-cli.js directly from the extracted path
+node .npm-upgrade/bin/npm-cli.js install -g .npm-upgrade
 
 URL="https://dl.cryptlex.com/downloads/"
 VERSION="v4.11.0";
@@ -10,4 +31,6 @@ cp ./tmp/linux/libs/musl/amd64/libLexFloatClient.a ./
 npm i
 node-gyp rebuild 
 cp ./build/Release/lexfloatclient.node ./lib/bindings/linux/musl/x64
+# Clean up
 rm -f LexFloatClient-Static-Linux.zip
+rm -rf npm.tgz .npm-upgrade


### PR DESCRIPTION
@adnan-kamili 

Reason for changes:
- The native addon uses BigInt types in the Node.js Addon API (N-API)
- Node.js 8 (previously used) doesn't support BigInt
- Node.js 12 provides stable BigInt support required for compilation
- Added dependencies to resolve missing symbol errors during build

I think we can move to node 12 as 8 is too old to support. Plus the musl arm too uses node 12.
